### PR TITLE
chore: fix jest-esm-transformer path

### DIFF
--- a/ui/packages/atlasmap-core/package.json
+++ b/ui/packages/atlasmap-core/package.json
@@ -82,7 +82,7 @@
     ],
     "testEnvironment": "jsdom",
     "transform": {
-      "/node_modules/monaco-editor": "jest-esm-transformer",
+      "monaco-editor": "jest-esm-transformer",
       "^.+\\.(ts|tsx)$": "ts-jest"
     },
     "transformIgnorePatterns": [

--- a/ui/packages/atlasmap-standalone/package.json
+++ b/ui/packages/atlasmap-standalone/package.json
@@ -98,7 +98,7 @@
       "monaco-editor": "monaco-editor/esm/vs/editor/editor.api.js"
     },
     "transform": {
-      "/node_modules/monaco-editor": "jest-esm-transformer",
+      "monaco-editor": "jest-esm-transformer",
       "^.+\\.(ts|tsx)$": "ts-jest"
     },
     "transformIgnorePatterns": [


### PR DESCRIPTION
This seems to work on both of linux and windows